### PR TITLE
Release Candidate 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ When obtaining a collection, you do not need to register it. Simply by asking fo
 When asking for a collection, you have the ability to pass in options that will allow the collection to enable certain features for that collection.
 
     $options = [
-        'versionTracking' => true
+        'versionTracking' => true,
+        'model' => 'MyCollectionModel'
     ];
     $collection = $db->collection('CollectionName', $options);
 
@@ -51,6 +52,7 @@ When asking for a collection, you have the ability to pass in options that will 
 | Option | Description | Value Type | Default Value |
 | - | - | - | - |
 | versionTracking | Turns on version tracking for objects within the collection. So whenever an object is updated or deleted, there will always be a trail of all past values for the objects within the collection. | boolean | false |
+| model | Will set the object type the collection represents. When you set this option, whenever you insert or update objects, if the object isn't of the type you set a SqlException will be thrown. Also, when you retrieve objects, you'll get back the appropriate object type. | string or null | null |
 
 ### Inserting Your First Object
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,41 +1,17 @@
 # Release Changes
 
+* 3.1.0
+    * Update FireSql to accept new option that will allow you to set a classname for the model so that all objects of a collection are returned as that object.
+    * Added type checking when inserting or updating objects in a collection that has a model type set.
 * 3.0.1
     * Update the render method logic in the sql debug panel to use $this->name instead of self::NAME.
     * Added description to the firesql debug panel.
 * 3.0.0
     * Uplifting code to be in line with UA1 Labs 2.0 standards.
     * Added test cases.
-* 2.1.0
-    * Adding documentation for source code and README.
-* 2.0.1
-    * Update Collection::update() method to return the updated object so a client knows when an object is truely updated.
-* 2.0.0
-    * Change database table structure so that a collection has its own set of tables and all collections do not continue to share the same two tables.
-* 1.4.1
-    * Update collection->find() so that when it is called with a objectId is only looks for the object within the collection and not all objects in the database.
-* 1.4.0
-    * Change the default behavior of upsertion. Currently, the default behavior is to track the history of any object in a collection. This change will update this functionality to make it an option rather than the default behavior. The new default behavior wil be to update any existing objects and not keep track of the history of an object.
-* 1.3.1
-    * Update sql queries to fix issues with newer version of mysql.
-* 1.3.0
-    * Add ability to pass in filter into collection->count() to get object count for the filter.
-* 1.2.0
-    * Add count method to collection that will return the number of objects in a collection.
-    * Update firebug panel to use the new firebug render helpers.
-* 1.1.1
-    * Update firesql.phtml to use the new renderTrace() available in the Fire\Bug\Panel object.
-    * Remove composer.lock as it is not needed because this is a library.
-    * Adjust upsert process to commit object using version as well as id.
-* 1.1.0
-    * Remove hard coded styles for hr in firesql.phtml
-    * Add count to the FireSql panel in firebug. It should read {2} FireSql
-* 1.0.0
-    * Initial Release
 
 **Steps To Create Release**
 
-1. Make sure all code is commented out in `demo/addRecords.php` and `demo/getRecords.php`.
 1. Add version changes to `RELEASE.md`.
 2. Update release version in `composer.json`.
 3. Merge changes to master branch and push master branch changes upstream.

--- a/UA1Labs/Fire/Sql.php
+++ b/UA1Labs/Fire/Sql.php
@@ -56,7 +56,8 @@ class Sql
      * Returns a collection object that will allow you to interact with the collection data.
      * Default $options:
      * [
-     *     'versionTracking' => false
+     *     'versionTracking' => false,
+     *     'model' => null
      * ]
      *
      * @param string $name The name of the collection

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ua1-labs/firesql",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "Set your SQL database on fire by making it into a NoSQL database.",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
In this release we wanted to add the capability for a developer to configure a collection so that it can be represented by a type. We added the ability to configure a `model` when obtaining a collection object.

Now as a developer, you will have the capability to configure a model:

    $myCollection = $sql->collection('MyCollection', ['model' => 'MyCollectionModel']);

Note: When a model is configured for a collection, an exception will be thrown if you try to insert or update the collection with objects that do not match the model type configured.

Also, when you retrieve items from a collection, they will be returned as the type configured.